### PR TITLE
Remove duplicate Connect Wallet button from hero section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,12 +70,9 @@ export default function Home() {
             
             {!isConnected ? (
               <div className="bg-blue-50 dark:bg-blue-950/30 rounded-lg p-6 max-w-md mx-auto">
-                <p className="text-lg text-blue-900 dark:text-blue-100 mb-4">
+                <p className="text-lg text-blue-900 dark:text-blue-100">
                   Connect your wallet to get started
                 </p>
-                <Wallet>
-                  <ConnectWallet className="!w-full" />
-                </Wallet>
               </div>
             ) : !showUpload ? (
               <button


### PR DESCRIPTION
## Changes
- Removed the duplicate Connect Wallet button that was appearing in the hero section
- Kept only the Connect Wallet button in the header (top right)
- Hero section now shows only the informational message when wallet not connected

## Screenshot
The user reported seeing two Connect Wallet buttons. This fix ensures only one button appears in the header.

## Testing
- Built and verified locally that only one Connect Wallet button appears
- Confirmed the hero section shows appropriate message without duplicate button